### PR TITLE
Fix error middleware crash

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -44,7 +44,8 @@ app.use((req, res, next) => {
     const message = err.message || "Internal Server Error";
 
     res.status(status).json({ message });
-    throw err;
+    // Don't crash the server after handling the error
+    log(`Error handled: ${status} ${message}`, "error");
   });
 
   // importantly only setup vite in development and after


### PR DESCRIPTION
## Summary
- handle errors gracefully without throwing

## Testing
- `npm run check` *(fails: Cannot find type definition file)*

------
https://chatgpt.com/codex/tasks/task_e_6853879bd1e88324ad1a60c1d37bcab8